### PR TITLE
Fixes the Nitro Preview in Settings

### DIFF
--- a/src/components/profile.css
+++ b/src/components/profile.css
@@ -317,6 +317,30 @@ div.customizationSection-IGy2fS.previewProfileThemes-ViDDkq
 	border: none;
 }
 
+/* fixes nitro preview in settings */
+
+.premiumFeatureBorder-1i95si .avatarUploaderPremium-2v2k2d {
+	top: 16px;
+}
+.premiumFeatureBorder-1i95si .avatarUploader-CHGwK7 {
+	position: absolute;
+	left: 33%;
+}
+.premiumFeatureBorder-1i95si .status-b9jLr4 {
+	background: var(--background-secondary);
+}
+.premiumFeatureBorder-1i95si .userPopoutOverlayBackground-dKOOda {
+	margin-top: 90px;
+}
+.premiumFeatureBorder-1i95si .userProfileInner-3F03PX {
+	background: var(--background-secondary);
+	min-height: 0;
+	max-height: 100%;
+}
+.premiumFeatureBorder-1i95si .profileCustomizationPreview-2-Y173 {
+	min-height: 0px;
+}
+
 /** Activity buttons*/
 /* make upgrade button blurple*/
 .button-35nmN9 {


### PR DESCRIPTION
I don't know how this change applies to anything *with* nitro but this always bothered me so I decided to change it

also as convenient as the whole push access thing was I feel like its better if I just stick to pull requests so you can review my shitty changes beforehand (in case I manage to fuck something up AGAIN, still sorry about that lmao)

Before:
![image](https://user-images.githubusercontent.com/83364207/226138514-8b830aae-e92f-4675-8976-7ba35d684b3e.png)

After:
![image](https://user-images.githubusercontent.com/83364207/226138517-a8675cfb-d0e3-4f2c-90ae-d05d14770615.png)


~~(also I couldn't access the dev menu for the longest time and I spent weeks trying to figure it out but it turns out my fuckin AMD software decided it would be a GREAT idea to enable the ctrl+shift+i shortcut which overrode the dev tools shortcut :/)~~