### PR TITLE
Reverts the red "Your Files Are Too Powerful" dialog

### DIFF
--- a/src/components/other.css
+++ b/src/components/other.css
@@ -1106,3 +1106,19 @@ taken from dtm-17 (im a lazy fuck :p)*/
 	background-color: #af1924;
 	background-image: url(https://cdn.discordapp.com/attachments/733624227378495488/1007053668836720710/991f3682123857c83ad3252a30023b1a.svg);
 }
+
+/* revert too powerful dialog */
+.uploadDropModal-13Kd20 .inner-rBP-MS .instructions-272j2A {
+	color: hsl(var(--white-500-hsl)/.4);
+}
+.uploadDropModal-13Kd20 .inner-rBP-MS {
+	border-radius: 5px;
+}
+/* force to use the video svg instead */
+.icons-1UZPvE > .wrapThree-3wCMkN > .icon-HW4tZ-.three-fZYihQ.code-rRQnfi {
+	background-image: url(https://discord.com/assets/dae57381bd2599b546fc014a41708c06.svg) !important;
+}
+/* force to use the code svg instead */
+.icons-1UZPvE > .wrapTwo-3T9wbh > .icon-HW4tZ-.two-1t2_74.image-2ssF8k {
+	background-image: url(https://discord.com/assets/4ab2ee5027741df387151ca717ae5614.svg) !important;
+}

--- a/src/main.css
+++ b/src/main.css
@@ -1,4 +1,3 @@
-@import url("https://damoyai.github.io/oldcord/src/components/hardcoded.css");
 @import url("https://damoyai.github.io/oldcord/src/components/vars.css");
 @import url("https://damoyai.github.io/oldcord/src/components/color.css");
 @import url("https://damoyai.github.io/oldcord/src/components/imgs.css");


### PR DESCRIPTION
haven't done anything for oldcord for a while and I know this is a small change but whatever I'm a perfectionist and I'll change the most random spots that almost no one will ever see lmfao

also I removed the `hardcoded.css` import from `main.css` because the file doesn't exist anymore

if I missed anything then lmk

Before
![image](https://user-images.githubusercontent.com/83364207/228117993-d30552f9-0d53-41e5-81e1-fe4f604b82fe.png)

After
![image](https://user-images.githubusercontent.com/83364207/228118020-4352194c-87fe-4f89-a03f-94828a247118.png)

<sub>also I made a plugin that changes the + button to its 2020 functionality you might wanna check that out perhaps 👉👈</sub>